### PR TITLE
feat: Add C++26-style println overloads

### DIFF
--- a/include/fmt/base.h
+++ b/include/fmt/base.h
@@ -2990,6 +2990,10 @@ FMT_INLINE void println(format_string<T...> fmt, T&&... args) {
   return fmt::println(stdout, fmt, static_cast<T&&>(args)...);
 }
 
+FMT_INLINE void println(FILE* f) { fmt::print(f, "\n"); }
+
+FMT_INLINE void println() { fmt::println(stdout); }
+
 FMT_PRAGMA_CLANG(diagnostic pop)
 FMT_PRAGMA_GCC(pop_options)
 FMT_END_EXPORT

--- a/include/fmt/ostream.h
+++ b/include/fmt/ostream.h
@@ -162,6 +162,8 @@ void println(std::ostream& os, format_string<T...> fmt, T&&... args) {
              fmt::format(fmt, std::forward<T>(args)...));
 }
 
+FMT_EXPORT void println(std::ostream& os) { fmt::print(os, FMT_STRING("\n")); }
+
 FMT_END_NAMESPACE
 
 #endif  // FMT_OSTREAM_H_

--- a/test/format-test.cc
+++ b/test/format-test.cc
@@ -1915,6 +1915,8 @@ TEST(format_test, print) {
   EXPECT_WRITE(stdout, fmt::println("Don't {}!", "panic"), "Don't panic!\n");
   EXPECT_WRITE(stderr, fmt::println(stderr, "Don't {}!", "panic"),
                "Don't panic!\n");
+  EXPECT_WRITE(stdout, fmt::println(), "\n");
+  EXPECT_WRITE(stderr, fmt::println(stderr), "\n");
 }
 
 TEST(format_test, big_print) {


### PR DESCRIPTION
<!--
Please read the contribution guidelines before submitting a pull request:
https://github.com/fmtlib/fmt/blob/master/CONTRIBUTING.md.
By submitting this pull request, you agree to license your contribution(s)
under the terms outlined in LICENSE.rst and represent that you have the right
to do so.
-->

Summary

- Add a set of convenience overloads for fmt::println to make common use-cases more concise and to align with C++26-style usability expectations.

What changed

- New overloads of println were added:
  - `void println()` — writes a newline to stdout.
  - `void println(FILE* f)` — writes a newline to a specified `FILE*`.
- These overloads forward to the existing `print` implementation.

Examples

- No-arg newline:
  - `fmt::println();`
- writes newline to a `FILE*` (stderr in this example):
  - `fmt::println(stderr);`
